### PR TITLE
Use `osc` for  credentials

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 python-rpm-spec
+osc

--- a/src/saltversions
+++ b/src/saltversions
@@ -45,33 +45,36 @@ class bcolors:
     UNDERLINE = "\033[4m"
 
 
-def fetch(repo, credentials):
+def fetch(repo, credentials, api_url):
     """
     Fetching the spec file from a repository.
     """
-    url = "https://api.opensuse.org/source/{}/salt/salt.spec".format(repo)
+    spec_url = "{}/source/{}/salt/salt.spec".format(api_url, repo)
     spec_file = requests.get(
-        url, auth=(credentials["username"], credentials["password"])
+        spec_url, auth=(credentials["username"], credentials["password"])
     )
     return repo, spec_file
 
 
 def main():
+    """
+    Entry point of the script.
+    """
     if (
         not all((environ.get("OSCUSER", None), environ.get("OSCPASS", None)))
         and not HAS_OSC
     ):
         print(
-            "Please provide username and password as environment varibales OSCUSER and OSCPASS.",
+            "Please provide username and password as environment variables OSCUSER and OSCPASS.",
             file=sys.stderr,
         )
         sys.exit(1)
 
-
     credentials = {}
+    api_url = "https://api.opensuse.org"
     if HAS_OSC:
         osc.conf.get_config()
-        apiconf = osc.conf.config["api_host_options"]["https://api.opensuse.org"]
+        apiconf = osc.conf.config["api_host_options"][api_url]
         credentials["username"] = apiconf["user"]
         credentials["password"] = apiconf["pass"]
     else:
@@ -79,8 +82,8 @@ def main():
         credentials["password"] = environ["OSCPASS"]
 
     with PoolExecutor(max_workers=4) as executor:
-        fetch_with_creds = partial(fetch, credentials=credentials)
-        for repo, spec_file in executor.map(fetch_with_creds, repos):
+        fetch_with_creds_host = partial(fetch, credentials=credentials, api_url=api_url)
+        for repo, spec_file in executor.map(fetch_with_creds_host, repos):
             if spec_file.status_code == 200:
                 spec = Spec.from_string(spec_file.text)
                 print("{}{}{}".format(bcolors.HEADER, repo, bcolors.ENDC))

--- a/src/saltversions
+++ b/src/saltversions
@@ -11,10 +11,17 @@ __license__ = "MIT"
 import sys
 from os import environ
 from concurrent.futures import ThreadPoolExecutor as PoolExecutor
+from functools import partial
 
 import requests
 from pyrpm.spec import Spec
 
+try:
+    import osc.conf
+
+    HAS_OSC = True
+except ImportError:
+    HAS_OSC = False
 
 repos = (
     "systemsmanagement:saltstack:products",
@@ -38,24 +45,42 @@ class bcolors:
     UNDERLINE = "\033[4m"
 
 
-def fetch(repo):
+def fetch(repo, credentials):
     """
     Fetching the spec file from a repository.
     """
     url = "https://api.opensuse.org/source/{}/salt/salt.spec".format(repo)
-    spec_file = requests.get(url, auth=(environ["OSCUSER"], environ["OSCPASS"]))
+    spec_file = requests.get(
+        url, auth=(credentials["username"], credentials["password"])
+    )
     return repo, spec_file
 
 
 def main():
-    if not all((environ.get("OSCUSER", None), environ.get("OSCPASS", None))):
+    if (
+        not all((environ.get("OSCUSER", None), environ.get("OSCPASS", None)))
+        and not HAS_OSC
+    ):
         print(
             "Please provide username and password as environment varibales OSCUSER and OSCPASS.",
             file=sys.stderr,
         )
         sys.exit(1)
+
+
+    credentials = {}
+    if HAS_OSC:
+        osc.conf.get_config()
+        apiconf = osc.conf.config["api_host_options"]["https://api.opensuse.org"]
+        credentials["username"] = apiconf["user"]
+        credentials["password"] = apiconf["pass"]
+    else:
+        credentials["username"] = environ["OSCUSER"]
+        credentials["password"] = environ["OSCPASS"]
+
     with PoolExecutor(max_workers=4) as executor:
-        for repo, spec_file in executor.map(fetch, repos):
+        fetch_with_creds = partial(fetch, credentials=credentials)
+        for repo, spec_file in executor.map(fetch_with_creds, repos):
             if spec_file.status_code == 200:
                 spec = Spec.from_string(spec_file.text)
                 print("{}{}{}".format(bcolors.HEADER, repo, bcolors.ENDC))


### PR DESCRIPTION
`osc` is used to read the API credentials if it is available, falling back to the same environment variables that are currently used if `osc` is not installed.